### PR TITLE
Vagrant support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ nosetests.xml
 
 # OS X
 .DS_Store
+
+# Vagrant
+.vagrant

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,11 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  config.vm.box = "ubuntu/trusty32"
+  config.ssh.forward_agent = true
+  config.vm.provision "shell", path: "etc/provision", privileged: false
+end

--- a/etc/provision
+++ b/etc/provision
@@ -2,4 +2,5 @@
 echo Provisioning...
 sudo sh -c 'date > /etc/vagrant_provisioned_at'
 sudo apt-get update
-sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -q python-twisted python-yaml python-bs4 python-tz
+sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -q libssl-dev libffi-dev python-pip libpython-dev
+sudo pip install -r /vagrant/requirements.txt

--- a/etc/provision
+++ b/etc/provision
@@ -2,4 +2,4 @@
 echo Provisioning...
 sudo sh -c 'date > /etc/vagrant_provisioned_at'
 sudo apt-get update
-sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -q python-twisted python-yaml
+sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -q python-twisted python-yaml python-bs4 python-tz

--- a/etc/provision
+++ b/etc/provision
@@ -1,0 +1,5 @@
+#!/bin/sh
+echo Provisioning...
+sudo sh -c 'date > /etc/vagrant_provisioned_at'
+sudo apt-get update
+sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -q python-twisted python-yaml


### PR DESCRIPTION
Support for Vagrant virtual machine. This should simplify development on various machines. Optionally there should be entry in Contributing section with info how to get Cardinal up and running with Vagrant.