### PR TITLE
Wiki plugin to handle UTF-8 characters solves #127

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -10,3 +10,4 @@ John Maguire <contact@johnmaguire.me>
 Shawn Smith <shawn.spamfilter@gmail.com>
 Sol Bekic <S0lll0s@blinkenshell.org>
 Tony Skuse <tskuse@gmail.com>
+Vineet Menon <mvineetmenon@gmail.com>

--- a/cardinal.py
+++ b/cardinal.py
@@ -68,6 +68,7 @@ https://github.com/JohnMaguire/Cardinal
     ))
     spec.add_option('channels', list, ['#bots'])
     spec.add_option('plugins', list, [
+        'wikipedia',
         'ping',
         'help',
         'admin',

--- a/plugins/wikipedia/plugin.py
+++ b/plugins/wikipedia/plugin.py
@@ -37,10 +37,10 @@ class WikipediaPlugin(object):
 
     def _get_article_info(self, name):
         name = name.replace(' ', '_')
-        url = "https://%s.wikipedia.org/wiki/%s" % (self._language_code, name)
+        url = "https://%s.wikipedia.org/wiki/%s" % (self._language_code, name.decode('UTF-8'))
 
         try:
-            uh = urllib2.urlopen(url)
+            uh = urllib2.urlopen(url.encode('UTF-8'))
             soup = BeautifulSoup(uh)
         except Exception, e:
             self.logger.warning(


### PR DESCRIPTION
@JohnMaguire, Please review these changes and see if they are okay for merging.

The unicode chars in url have to be preserved till the final stage in `urlopen (wikipedia/plugin:53)`, where the unicode string is encoded.