### PR TITLE
[plugins] Change weather API to OpenWeatherMap

### DIFF
--- a/plugins/weather/config.json
+++ b/plugins/weather/config.json
@@ -1,0 +1,3 @@
+{
+	"api_key": "7d00a4a07f7d55d9894aae06b0b473cb"
+}

--- a/plugins/weather/plugin.py
+++ b/plugins/weather/plugin.py
@@ -1,33 +1,46 @@
 import logging
 
 import requests
-from requests import Response
+from twisted.internet import defer
+from twisted.internet.threads import deferToThread
 
 from cardinal.decorators import command, help
 
 API_ENDPOINT = "https://api.openweathermap.org/data/2.5/weather"
-# Hardcoded key for Cardinal
-API_KEY = "7d00a4a07f7d55d9894aae06b0b473cb"
 
 
 class WeatherPlugin:
-    def __init__(self, cardinal):
+    def __init__(self, cardinal, config=None):
         self.logger = logging.getLogger(__name__)
         self.db = cardinal.get_db('weather')
 
-    def get_forecast(self, location) -> Response:
+        if config is None:
+            return
+
+        if 'api_key' in config:
+            self.api_key = config['api_key']
+
+    @defer.inlineCallbacks
+    def _get_forecast(self, location):
         params = {
             'q': location,
-            'appid': API_KEY,
+            'appid': self.api_key,
             'units': 'imperial',
             'lang': 'en',
         }
 
-        return requests.get(API_ENDPOINT, params=params)
+        r = yield deferToThread(
+            requests.get,
+            API_ENDPOINT,
+            params=params
+        )
+
+        return r.json()
 
     @command('setw')
     @help("Set your default weather location.")
     @help("Syntax: .setw <location>")
+    @defer.inlineCallbacks
     def set_weather(self, cardinal, user, channel, msg):
         try:
             location = msg.split(' ', 1)[1]
@@ -36,7 +49,7 @@ class WeatherPlugin:
             return
 
         try:
-            res = self.get_forecast(location).json()
+            res = yield self._get_forecast(location)
             location = "{}, {}".format(res['name'].strip(),
                                        res['sys']['country'].strip())
         except Exception:
@@ -57,7 +70,15 @@ class WeatherPlugin:
     @command(['weather', 'w'])
     @help("Retrieves the weather using the OpenWeatherMap API.")
     @help("Syntax: .weather [location]")
+    @defer.inlineCallbacks
     def weather(self, cardinal, user, channel, msg):
+        if self.api_key is None:
+            cardinal.sendMsg(
+                channel,
+                "Weather plugin is not configured correctly. "
+                "Please set API key."
+            )
+
         try:
             location = msg.split(' ', 1)[1]
         except IndexError:
@@ -73,7 +94,7 @@ class WeatherPlugin:
                     return
 
         try:
-            res = self.get_forecast(location).json()
+            res = yield self._get_forecast(location)
         except Exception:
             cardinal.sendMsg(channel, "Error fetching weather data.")
             self.logger.exception(
@@ -81,11 +102,14 @@ class WeatherPlugin:
             return
 
         try:
+            self.logger.exception(
+                res
+            )
             location = "{}, {}".format(res['name'].strip(),
                                        res['sys']['country'].strip())
         except KeyError:
             cardinal.sendMsg(channel,
-                             "Couldn't find weather data for your location.")
+                             "Couldn't find weather data for your location: {}".format(location))
             return
 
         condition = res['weather'][0]['main']


### PR DESCRIPTION
Fixes #191.

- Now uses the OpenWeatherMap API ([docs](https://openweathermap.org/current)) for weather data
- By default, the API endpoint requires different parameters depending on whether the location is a city name, city id, geographical coordinates or a zip code. It might make sense to use something like [`geopy`](https://github.com/geopy/geopy) to get a standard lat/lon format for all locations. 