### PR TITLE
User-configurable command prefix

### DIFF
--- a/cardinal.py
+++ b/cardinal.py
@@ -72,6 +72,7 @@ https://github.com/JohnMaguire/Cardinal
         'urbandict',
         'seen'
     ])
+    spec.add_option('cmd_prefix', str, '.')
     spec.add_option('blacklist', dict, {})
     spec.add_option('logging', dict, None)
 
@@ -129,6 +130,7 @@ https://github.com/JohnMaguire/Cardinal
                                  config['username'],
                                  config['realname'],
                                  config['plugins'],
+                                 config['cmd_prefix'],
                                  config['blacklist'],
                                  config['storage'])
 

--- a/cardinal/bot.py
+++ b/cardinal/bot.py
@@ -124,6 +124,7 @@ class CardinalBot(irc.IRCClient, object):
         # Setup PluginManager
         self.plugin_manager = PluginManager(self,
                                             self.factory.plugins,
+                                            self.factory.cmd_prefix,
                                             self.factory.blacklist)
 
         if self.factory.server_commands:
@@ -639,6 +640,7 @@ class CardinalBotFactory(protocol.ClientFactory):
                  username,
                  realname,
                  plugins,
+                 cmd_prefix,
                  blacklist,
                  storage):
         """Boots the bot, triggers connection, and initializes logging.
@@ -653,6 +655,7 @@ class CardinalBotFactory(protocol.ClientFactory):
           username -- A string with the ident to be used.
           realname -- A string containing the real name field.
           plugins -- A list of plugins to load on boot.
+          cmd_prefix -- A string containing the command prefix.
           blacklist -- A dict mapping plugins to lists of blacklisted channels.
           storage -- A string containing path to storage directory.
         """
@@ -666,6 +669,7 @@ class CardinalBotFactory(protocol.ClientFactory):
         self.username = username
         self.realname = realname
         self.plugins = plugins
+        self.cmd_prefix = cmd_prefix
         self.blacklist = blacklist
         self.storage_path = storage
 

--- a/config/config.example.json
+++ b/config/config.example.json
@@ -31,6 +31,8 @@
         "youtube"
     ],
 
+    "cmd_prefix": "."
+
     "logging": {
         "version": 1,
 

--- a/plugins/8ball/plugin.py
+++ b/plugins/8ball/plugin.py
@@ -9,7 +9,7 @@ from cardinal.util import sleep
 class Magic8BallPlugin:
     @command(['8', '8ball'])
     @help("Ask the might 8-ball a question.")
-    @help("Syntax: .8 <question>")
+    @help("Syntax: @8 <question>")
     @defer.inlineCallbacks
     def answer(self, cardinal, user, channel, msg):
         if not (msg.endswith("?") and len(msg.split()) > 1):

--- a/plugins/admin/plugin.py
+++ b/plugins/admin/plugin.py
@@ -44,7 +44,7 @@ class AdminPlugin:
     @command('eval')
     @help("A super dangerous command that runs eval() on the input. "
           "(admin only)")
-    @help("Syntax: .eval <command>")
+    @help("Syntax: @eval <command>")
     def eval(self, cardinal, user, channel, msg):
         if self.is_admin(user):
             command = ' '.join(msg.split()[1:])
@@ -60,7 +60,7 @@ class AdminPlugin:
     @command('exec')
     @help("A dangerous command that runs exec() on the input. " +
           "(admin only)")
-    @help("Syntax: .exec <command>")
+    @help("Syntax: @exec <command>")
     def execute(self, cardinal, user, channel, msg):
         if self.is_admin(user):
             command = ' '.join(msg.split()[1:])
@@ -76,7 +76,7 @@ class AdminPlugin:
     @command(['load', 'reload'])
     @help("If no plugins are given after the command, reload all plugins. "
           "Otherwise, load (or reload) the selected plugins. (admin only)")
-    @help("Syntax: .load [plugin [plugin ...]]")
+    @help("Syntax: @load [plugin [plugin ...]]")
     def load_plugins(self, cardinal, user, channel, msg):
         if self.is_admin(user):
             cardinal.sendMsg(channel, "%s: Loading plugins..." % user.nick)
@@ -105,7 +105,7 @@ class AdminPlugin:
 
     @command('unload')
     @help("Unload selected plugins. (admin only)")
-    @help("Syntax: .unload <plugin [plugin ...]>")
+    @help("Syntax: @unload <plugin [plugin ...]>")
     def unload_plugins(self, cardinal, user, channel, msg):
         nick = user.nick
 
@@ -135,7 +135,7 @@ class AdminPlugin:
 
     @command('disable')
     @help("Disable plugins in a channel. (admin only)")
-    @help("Syntax: .disable <plugin> <channel [channel ...]>")
+    @help("Syntax: @disable <plugin> <channel [channel ...]>")
     def disable_plugins(self, cardinal, user, channel, msg):
         if not self.is_admin(user):
             return
@@ -164,7 +164,7 @@ class AdminPlugin:
 
     @command('enable')
     @help("Enable plugins in a channel. (admin only)")
-    @help("Syntax: .enable <plugin> <channel [channel ...]>")
+    @help("Syntax: @enable <plugin> <channel [channel ...]>")
     def enable_plugins(self, cardinal, user, channel, msg):
         if not self.is_admin(user):
             return
@@ -202,7 +202,7 @@ class AdminPlugin:
 
     @command('join')
     @help("Joins selected channels. (admin only)")
-    @help("Syntax: .join <channel [channel ...]>")
+    @help("Syntax: @join <channel [channel ...]>")
     def join(self, cardinal, user, channel, msg):
         if self.is_admin(user):
             channels = msg.split()
@@ -212,7 +212,7 @@ class AdminPlugin:
 
     @command('part')
     @help("Parts selected channels. (admin only)")
-    @help("Syntax: .join <channel [channel ...]>")
+    @help("Syntax: @join <channel [channel ...]>")
     def part(self, cardinal, user, channel, msg):
         if not self.is_admin(user):
             return
@@ -228,7 +228,7 @@ class AdminPlugin:
     @command('quit')
     @help("Quits the network with a quit message, if one is defined. "
           "(admin only)")
-    @help("Syntax: .quit [message]")
+    @help("Syntax: @quit [message]")
     def quit(self, cardinal, user, channel, msg):
         if self.is_admin(user):
             cardinal.disconnect(' '.join(msg.split(' ')[1:]))
@@ -236,7 +236,7 @@ class AdminPlugin:
     @command('dbg_quit')
     @help("Quits the network without setting disconnect flag "
           "(for testing reconnection, admin only)")
-    @help("Syntax: .dbg_quit")
+    @help("Syntax: @dbg_quit")
     def debug_quit(self, cardinal, user, channel, msg):
         if self.is_admin(user):
             cardinal.quit('Debug disconnect')

--- a/plugins/crypto/plugin.py
+++ b/plugins/crypto/plugin.py
@@ -61,7 +61,7 @@ class CryptoPlugin:
 
     @command('crypto')
     @help('Check the price of a cryptocurrency')
-    @help('Syntax: .crypto <cryptocurrency,...> [price currency]')
+    @help('Syntax: @crypto <cryptocurrency,...> [price currency]')
     @defer.inlineCallbacks
     def crypto(self, cardinal, user, channel, message):
         nick = user.nick

--- a/plugins/github/plugin.py
+++ b/plugins/github/plugin.py
@@ -41,7 +41,7 @@ class GithubPlugin:
 
     @command('issue')
     @help("Find a Github repo or issue (or combination thereof)")
-    @help("Syntax: .issue [username/repository] <id or search query>")
+    @help("Syntax: @issue [username/repository] <id or search query>")
     @defer.inlineCallbacks
     def search(self, cardinal, user, channel, msg):
         # Grab the search query

--- a/plugins/google/plugin.py
+++ b/plugins/google/plugin.py
@@ -12,7 +12,7 @@ class GoogleSearch:
 
     @command(['google', 'lmgtfy', 'g'])
     @help("Returns the URL of the top result for a given search query")
-    @help("Syntax: .google <query>")
+    @help("Syntax: @google <query>")
     def query(self, cardinal, user, channel, msg):
         # gets search string from message, and makes it url safe
         try:

--- a/plugins/lastfm/plugin.py
+++ b/plugins/lastfm/plugin.py
@@ -47,7 +47,7 @@ class LastfmPlugin:
 
     @command('setlastfm')
     @help(["Sets the default Last.fm username for your nick.",
-           "Syntax: .setlastfm <username>"])
+           "Syntax: @setlastfm <username>"])
     def set_user(self, cardinal, user, channel, msg):
         if not self.conn:
             cardinal.sendMsg(
@@ -106,7 +106,7 @@ class LastfmPlugin:
     @command(['np', 'nowplaying'])
     @help("Get the Last.fm track currently played by a user (defaults to "
           "username set with .setlastfm)")
-    @help("Syntax: .np [Last.fm username]")
+    @help("Syntax: @np [Last.fm username]")
     @defer.inlineCallbacks
     def now_playing(self, cardinal, user, channel, msg):
         # Open the cursor for the query to find a saved Last.fm username

--- a/plugins/movies/plugin.py
+++ b/plugins/movies/plugin.py
@@ -132,21 +132,21 @@ class MoviePlugin:
 
     @command('movie')
     @help('Get the first movie IMDb result for a given search')
-    @help('Syntax: .movie <search query>')
+    @help('Syntax: @movie <search query>')
     @defer.inlineCallbacks
     def movie(self, cardinal, user, channel, msg):
         yield self.imdb(cardinal, user, channel, msg, result_type='movie')
 
     @command('show')
     @help('Get the first TV show IMDb result for a given search')
-    @help('Syntax: .show <search query>')
+    @help('Syntax: @show <search query>')
     @defer.inlineCallbacks
     def show(self, cardinal, user, channel, msg):
         yield self.imdb(cardinal, user, channel, msg, result_type='series')
 
     @command(['omdb', 'imdb'])
     @help('Get the first IMDb result for a given search')
-    @help('Syntax: .imdb <search query>')
+    @help('Syntax: @imdb <search query>')
     @defer.inlineCallbacks
     def imdb(self, cardinal, user, channel, msg, result_type=None):
         # Before we do anything, let's make sure we'll be able to query omdb.
@@ -212,7 +212,7 @@ class MoviePlugin:
 
     @command('search')
     @help('Return IMDb search results (use .imdb for a single title)')
-    @help('Syntax: .search <search query>')
+    @help('Syntax: @search <search query>')
     @defer.inlineCallbacks
     def search(self, cardinal, user, channel, msg):
         if self.api_key is None:

--- a/plugins/random/plugin.py
+++ b/plugins/random/plugin.py
@@ -35,7 +35,7 @@ def parse_roll(arg):
 class RandomPlugin:
     @command('roll')
     @help("Roll dice")
-    @help("Syntax: .roll #d# (e.g. .roll 2d6)")
+    @help("Syntax: @roll #d# (e.g. .roll 2d6)")
     def roll(self, cardinal, user, channel, msg):
         args = msg.split(' ')
         args.pop(0)

--- a/plugins/remind/plugin.py
+++ b/plugins/remind/plugin.py
@@ -9,7 +9,7 @@ class RemindPlugin:
 
     @command('remind')
     @help("Sends a reminder after a set time.")
-    @help("Syntax: .remind <minutes> <message>")
+    @help("Syntax: @remind <minutes> <message>")
     def remind(self, cardinal, user, channel, msg):
         message = msg.split(None, 2)
         if len(message) < 3:

--- a/plugins/seen/plugin.py
+++ b/plugins/seen/plugin.py
@@ -210,7 +210,7 @@ class SeenPlugin:
 
     @command('seen')
     @help("Returns the last time a user was seen, and their last action.")
-    @help("Syntax: .seen <user>")
+    @help("Syntax: @seen <user>")
     def seen(self, cardinal, user, channel, msg):
         try:
             nick = msg.split(' ')[1]
@@ -225,7 +225,7 @@ class SeenPlugin:
 
     @command('tell')
     @help("Tell an offline user something when they come online.")
-    @help("Syntax: .tell <nick> <message>")
+    @help("Syntax: @tell <nick> <message>")
     def tell(self, cardinal, user, channel, msg):
         try:
             nick, message = msg.split(' ', 2)[1:]

--- a/plugins/ticker/plugin.py
+++ b/plugins/ticker/plugin.py
@@ -333,7 +333,7 @@ class TickerPlugin:
 
     @command('stock')
     @help("Check the latest price of a stock")
-    @help("Syntax: .stock <stock symbol>")
+    @help("Syntax: @stock <stock symbol>")
     @defer.inlineCallbacks
     def stock(self, cardinal, user, channel, msg):
         nick = user.nick  # other values may not exist for relayed users
@@ -381,7 +381,7 @@ class TickerPlugin:
 
     @command('predict')
     @help("Predict a stock price at the next market open/close")
-    @help("Syntax: .predict <stock> [-]<X>%  |  .predict <stock> $<X>")
+    @help("Syntax: @predict <stock> [-]<X>%  |  @predict <stock> $<X>")
     @defer.inlineCallbacks
     def predict(self, cardinal, user, channel, msg):
         nick = user.nick

--- a/plugins/timezone/plugin.py
+++ b/plugins/timezone/plugin.py
@@ -11,7 +11,7 @@ TIME_FORMAT = '%b %d, %I:%M:%S %p UTC%z'
 class TimezonePlugin:
     @command(['time'])
     @help("Returns the current time in a given time zone or GMT offset.")
-    @help("Syntax: time <GMT offset or timezone>")
+    @help("Syntax: @time <GMT offset or timezone>")
     def get_time(self, cardinal, user, channel, msg):
         utc = pytz.utc
         now = datetime.now(utc)

--- a/plugins/tv/plugin.py
+++ b/plugins/tv/plugin.py
@@ -185,7 +185,7 @@ class TVPlugin:
 
     @command('ep')
     @help('Get air date info for a TV show.')
-    @help('Syntax: .ep <tv show>')
+    @help('Syntax: @ep <tv show>')
     @defer.inlineCallbacks
     def next_air_date(self, cardinal, user, channel, msg):
         try:

--- a/plugins/urbandict/plugin.py
+++ b/plugins/urbandict/plugin.py
@@ -16,7 +16,7 @@ class UrbanDictPlugin:
     @defer.inlineCallbacks
     @command(['ud', 'urbandict'])
     @help('Returns the top Urban Dictionary definition for a given word.')
-    @help('Syntax: .ud <word>')
+    @help('Syntax: @ud <word>')
     def get_ud(self, cardinal, user, channel, msg):
         try:
             word = msg.split(' ', 1)[1]

--- a/plugins/weather/plugin.py
+++ b/plugins/weather/plugin.py
@@ -117,7 +117,7 @@ class WeatherPlugin:
 
     @command('setw')
     @help("Set your default weather location.")
-    @help("Syntax: .setw <location>")
+    @help("Syntax: @setw <location>")
     @defer.inlineCallbacks
     def set_weather(self, cardinal, user, channel, msg):
         try:
@@ -145,7 +145,7 @@ class WeatherPlugin:
 
     @command(['weather', 'w'])
     @help("Retrieves the weather using the OpenWeatherMap API.")
-    @help("Syntax: .weather [location]")
+    @help("Syntax: @weather [location]")
     @defer.inlineCallbacks
     def weather(self, cardinal, user, channel, msg):
         if self.api_key is None:

--- a/plugins/wikipedia/plugin.py
+++ b/plugins/wikipedia/plugin.py
@@ -97,7 +97,7 @@ class WikipediaPlugin:
 
     @command(['wiki', 'wikipedia'])
     @help("Gets a summary and link to a Wikipedia page")
-    @help("Syntax: .wiki <article>")
+    @help("Syntax: @wiki <article>")
     @defer.inlineCallbacks
     def wiki(self, cardinal, user, channel, message):
         name = message.split(' ', 1)[1]

--- a/plugins/wolframalpha/plugin.py
+++ b/plugins/wolframalpha/plugin.py
@@ -34,7 +34,7 @@ class WolframAlphaPlugin:
 
     @command(['wolfram', 'calc'])
     @help('Make a query with Wolfram Alpha')
-    @help('Syntax: .wolfram <query>')
+    @help('Syntax: @wolfram <query>')
     @defer.inlineCallbacks
     def wolfram(self, cardinal, user, channel, message):
         try:

--- a/plugins/youtube/plugin.py
+++ b/plugins/youtube/plugin.py
@@ -12,6 +12,7 @@ from cardinal.exceptions import EventRejectedMessage
 VIDEO_URL_REGEX = re.compile(r'https?:\/\/(?:www\.)?youtube\..{2,4}\/watch\?.*(?:v=(.+?))(?:(?:&.*)|$)', flags=re.IGNORECASE)  # noqa: E501
 VIDEO_URL_SHORT_REGEX = re.compile(r'https?:\/\/(?:www\.)?youtu\.be\/(.+?)(?:(?:\?.*)|$)', flags=re.IGNORECASE)  # noqa: E501
 
+
 # Fetched from the YouTube API on 2021-06-04, hopefully it doesn't change.
 MUSIC_CATEGORY_ID = 10
 
@@ -66,7 +67,7 @@ class YouTubePlugin:
 
     @command(['youtube', 'yt'])
     @help("Get the first YouTube result for a given search.")
-    @help("Syntax: .youtube <search query>")
+    @help("Syntax: @youtube <search query>")
     @defer.inlineCallbacks
     def search(self, cardinal, user, channel, msg):
         # Before we do anything, let's make sure we'll be able to query YouTube


### PR DESCRIPTION
Attempting to solve issue https://github.com/JohnMaguire/Cardinal/issues/189

Here's how the prefix is passed between the modules and where it's being kept, in a (more or less) step-by-step list: 
1. `cardinal.py` attempts to load `cmd_prefix` from the config file, if it exists. Defaults to `.` if it doesn't exist. 
1. `CardinalBotFactory` contains `cmd_prefix` as an instance variable. 
1. `CardinalBot` reads the prefix from the factory, then passes the prefix to `PluginManager` (https://github.com/dkim286/Cardinal/blob/c0786e728a139f0b77e59e0b9fef6d9cf776888d/cardinal/bot.py#L124-L128).
1. `PluginManager` uses the prefix to build its `COMMAND_REGEX` instance variable (https://github.com/dkim286/Cardinal/blob/c0786e728a139f0b77e59e0b9fef6d9cf776888d/cardinal/plugins.py#L61-L63)
1. Plugin manager's `_instantiate_plugin()` function checks if a module accepts a `cmd_prefix` argument (https://github.com/dkim286/Cardinal/blob/c0786e728a139f0b77e59e0b9fef6d9cf776888d/cardinal/plugins.py#L189-L203). 
1. Any plugin that expects `cmd_prefix` from the plugin manager is aware of the custom prefix (e.g. `help`: https://github.com/dkim286/Cardinal/blob/c0786e728a139f0b77e59e0b9fef6d9cf776888d/plugins/help/plugin.py#L11-L12). 

Unfortunately, this does mean that the syntax help for each command had to be changed slightly. I went with the `@` symbol. For example, `help` plugin's command: 

```python
    @command(['help'])
    @help("Shows loaded commands or a specific command's help.")
    @help("Syntax: @help [command]")
    def cmd_help(self, cardinal, user, channel, msg):
```

The "placeholder" token is replaced from within the `help` plugin with a string replace function (https://github.com/dkim286/Cardinal/blob/c0786e728a139f0b77e59e0b9fef6d9cf776888d/plugins/help/plugin.py#L87-L93): 
```python
    # Replace the command prefix placeholder (@) with the user-defined prefix
    def _replace_prefix(self, help_msg):
        if isinstance(help_msg, list):
            correct_help_msg = [line.replace(PREFIX_PLACEHOLDER, self._cmd_prefix) for line in help_msg]
        else:
            correct_help_msg = help_msg.replace(PREFIX_PLACEHOLDER, self._cmd_prefix)
        return correct_help_msg
```

I went ahead and changed all the plugins' syntax help messages to use the `@` symbol.

It does seem to work for most commands. I have not tested this with the `ticker` module, as I don't have an API for it.

Screenshot of the bot in action, default configuration: 

![2021-06-28_00-05](https://user-images.githubusercontent.com/61002244/123594440-3f9f1080-d7df-11eb-8ef2-0d7d8f5ee536.png)

Screenshot of the bot in action, configured to use `!` for prefix:

![2021-06-28_00-06](https://user-images.githubusercontent.com/61002244/123594491-4cbbff80-d7df-11eb-85f5-3a4aee59b964.png)

