### PR TITLE
Workaround for breaking OpenSSL 3.9 change

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ Twisted==22.10.0
 
 # SSL connections
 pyOpenSSL==22.0.0
+cryptography==38.0.4
 service_identity==21.1.0
 
 # Various URL scraping plugins


### PR DESCRIPTION
This is hopefully a temporary workaround until upstream libraries can be patched for OpenSSL 3.9.

## Description
See #200 for context.  OpenSSL 3.9 has a breaking change that conflicts with Twisted and maybe other libraries in Cardinal.

## Test Plan
I tested this change locally and verified that Cardinal now starts with this change after a fresh container image build using python 3.11 images.

## Contribution Checklist
- [x] I have read the [contributing guidelines](https://github.com/JohnMaguire/Cardinal/blob/master/CONTRIBUTING.md).
- [x] I consent to the [MIT project license](https://github.com/JohnMaguire/Cardinal/blob/master/LICENSE).
- [ ] I have added my name to the [`CONTRIBUTORS`](https://github.com/JohnMaguire/Cardinal/blob/master/CONTRIBUTORS) file if desired (optional).
