### PR TITLE
Update plugin.py

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -12,3 +12,4 @@ Shawn Smith <shawn.spamfilter@gmail.com>
 Sol Bekic <S0lll0s@blinkenshell.org>
 Tony Skuse <tskuse@gmail.com>
 Vineet Menon <mvineetmenon@gmail.com>
+Scott A. Williams <vwbusguy@fedoraproject.org>

--- a/plugins/weather/plugin.py
+++ b/plugins/weather/plugin.py
@@ -115,7 +115,7 @@ class WeatherPlugin:
         else:
             raise Exception(f"Unknown weather provider: {self.provider}")
 
-    @command('setw')
+    @command(['setweather','setw'])
     @help("Set your default weather location.")
     @help("Syntax: .setw <location>")
     @defer.inlineCallbacks


### PR DESCRIPTION
Allow `.setweather` to work the same as `.setw` for consistency.

<!-- Provide a general summary of your changes in the Title above -->

## Description
Add `.setweather` in addition to `.setw` 

This change seems in-line with the [original author intent](https://github.com/johnmaguire/Cardinal/issues/156), is intuitive for some users, and would bring consistency in comparison to similar IRC bots.  For example, this interaction on IRC today with another user interacting with a Cardinal bot and another bot with a similar service:

![image](https://github.com/user-attachments/assets/a8eb302e-65e2-47cc-82d1-1b6caf3ff105)


## Test Plan
Verify that `.setw` and `.setweather` are both capable of setting the user's weather preference.

## Contribution Checklist
- [x] I have read the [contributing guidelines](https://github.com/JohnMaguire/Cardinal/blob/master/CONTRIBUTING.md).
- [x] I consent to the [MIT project license](https://github.com/JohnMaguire/Cardinal/blob/master/LICENSE).
- [x] I have added my name to the [`CONTRIBUTORS`](https://github.com/JohnMaguire/Cardinal/blob/master/CONTRIBUTORS) file if desired (optional).
