### PR TITLE
Dcc send files

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -13,3 +13,4 @@ Sol Bekic <S0lll0s@blinkenshell.org>
 Tony Skuse <tskuse@gmail.com>
 Vineet Menon <mvineetmenon@gmail.com>
 Scott A. Williams <vwbusguy@fedoraproject.org>
+Jason McKee <jason.mckee86@gmail.com>

--- a/cardinal/bot.py
+++ b/cardinal/bot.py
@@ -7,6 +7,7 @@ import shutil
 import socket
 import struct
 import random
+import requests
 from collections import namedtuple
 from contextlib import contextmanager
 from datetime import datetime
@@ -612,28 +613,39 @@ class CardinalBot(irc.IRCClient, object):
         self.msg(channel, message, length)
 
     def senddccfile(self, user, filePath):
-        """Initiates a DCC SEND transfer with a timeout."""
-        ip = socket.gethostbyname(socket.gethostname())  # Get local IP
+        def get_external_ip():
+            try:
+                return requests.get("https://checkip.amazonaws.com").text.strip()
+            except:
+                return socket.gethostbyname(socket.gethostname())  # Fallback to local IP
+        """Initiates a DCC SEND transfer with a fixed port range and correct IP."""
+        ip = get_external_ip()  # ✅ Get external IP
         ipint = struct.unpack("!I", socket.inet_aton(ip))[0]  # Convert IP to integer format
 
-        # Bind to an available port within 1024-5000
-        listener = reactor.listenTCP(0, DCCSendFactory(filePath, None))  # Use port 0 for auto-assign
+        fileName = os.path.basename(filePath)  # Get the filename
+        fileSize = os.path.getsize(filePath)  # Get the file size
+
+        # Extract the nickname from the user object
+        nick = user.nick if hasattr(user, "nick") else user[0]
+
+        # Pick a port between 1024 and 5000
+        port = random.randint(1024, 5000)
+
+        # Create a single instance of DCCSendFactory
+        factory = DCCSendFactory(filePath)  # Only pass filePath
+        listener = reactor.listenTCP(port, factory)  # ✅ Use a fixed port range
         assignedPort = listener.getHost().port  # Retrieve assigned port
 
         # Create a timeout to close the socket if no connection is made
-        timeoutDeferred = reactor.callLater(60, self.canceldccrequest, listener, user)
+        timeoutDeferred = reactor.callLater(60, self.canceldccrequest, listener, nick)
 
-        # Update the factory to include the timeout
-        listener.factory = DCCSendFactory(filePath, timeoutDeferred)
+        # Store timeout inside the factory
+        factory.timeoutDeferred = timeoutDeferred
 
-        fileSize = os.path.getsize(filePath)
-        fileName = os.path.basename(filePath)
+        # Corrected CTCP format (Pass only the extracted nickname)
+        self.ctcpMakeQuery(nick, [("DCC", f"SEND {fileName} {ipint} {assignedPort} {fileSize}")])
 
-        # Construct and send the DCC SEND CTCP message
-        dcc_msg = f"\x01DCC SEND {fileName} {ipint} {assignedPort} {fileSize}\x01"
-        self.ctcpMakeQuery(user, [dcc_msg])
-
-        print(f"Started DCC SEND for {fileName} to {user} on port {assignedPort}")
+        print(f"Started DCC SEND for {fileName} to {nick} on port {assignedPort}")
     
     def canceldccrequest(self, listener, user):
         """Cancel the DCC request if the receiver does not accept within the timeout."""

--- a/cardinal/bot.py
+++ b/cardinal/bot.py
@@ -4,6 +4,9 @@ import logging
 import os
 import re
 import shutil
+import socket
+import struct
+import random
 from collections import namedtuple
 from contextlib import contextmanager
 from datetime import datetime
@@ -29,6 +32,35 @@ user_info = namedtuple('user_info', ('nick', 'user', 'vhost'))
 UNLOCKED = 'unlocked'
 LOCKED = 'locked'
 
+class DCCSendProtocol(protocol.Protocol):
+    """Handles the actual file sending over DCC."""
+    def __init__(self, file_path):
+        self.file_path = file_path
+        self.file = open(file_path, "rb")
+    
+    def connectionMade(self):
+        """Start sending the file once a connection is made."""
+        print("DCC connection established, sending file...")
+        self.sendNextChunk()
+
+    def sendNextChunk(self):
+        """Send the next chunk of the file."""
+        chunk = self.file.read(1024)
+        if chunk:
+            self.transport.write(chunk)
+            reactor.callLater(0.1, self.sendNextChunk)
+        else:
+            print("File transfer complete.")
+            self.file.close()
+            self.transport.loseConnection()
+
+class DCCSendFactory(protocol.Factory):
+    """Creates the protocol instance for sending the file."""
+    def __init__(self, file_path):
+        self.file_path = file_path
+
+    def buildProtocol(self, addr):
+        return DCCSendProtocol(self.file_path)
 
 class CardinalBot(irc.IRCClient, object):
     """Cardinal, in all its glory"""
@@ -578,6 +610,26 @@ class CardinalBot(irc.IRCClient, object):
         self.logger.info("Sending in %s: %s" % (channel, message))
 
         self.msg(channel, message, length)
+
+    def senddccfile(self, user, filepath):
+        """Initiates a DCC SEND transfer with a dynamically selected port."""
+        ip = socket.gethostbyname(socket.gethostname())  # Get local IP
+        ipint = struct.unpack("!I", socket.inet_aton(ip))[0]  # Convert to integer
+
+        # Select a random port in the 1024-5000 range
+        port = random.randint(1024, 5000)
+
+        fileSize = os.path.getsize(filepath)
+        fileName = os.path.basename(filepath)
+
+        # Start listening for DCC connection
+        listener = reactor.listenTCP(0, DCCSendFactory(filepath))  # Port 0 = auto-assign
+        assignedPort = listener.getHost().port  # Get the assigned port
+
+        dccmsg = f"\x01DCC SEND {fileName} {ipint} {assignedPort} {fileSize}\x01"
+        self.ctcpMakeQuery(user, [dccmsg])
+
+        self.logger.info(f"Started DCC SEND for {fileName} on port {assignedPort}")
 
     def send(self, message):
         """Send a raw message to the server.

--- a/cardinal/bot.py
+++ b/cardinal/bot.py
@@ -611,25 +611,35 @@ class CardinalBot(irc.IRCClient, object):
 
         self.msg(channel, message, length)
 
-    def senddccfile(self, user, filepath):
-        """Initiates a DCC SEND transfer with a dynamically selected port."""
+    def senddccfile(self, user, filePath):
+        """Initiates a DCC SEND transfer with a timeout."""
         ip = socket.gethostbyname(socket.gethostname())  # Get local IP
-        ipint = struct.unpack("!I", socket.inet_aton(ip))[0]  # Convert to integer
+        ipint = struct.unpack("!I", socket.inet_aton(ip))[0]  # Convert IP to integer format
 
-        # Select a random port in the 1024-5000 range
-        port = random.randint(1024, 5000)
+        # Bind to an available port within 1024-5000
+        listener = reactor.listenTCP(0, DCCSendFactory(filePath, None))  # Use port 0 for auto-assign
+        assignedPort = listener.getHost().port  # Retrieve assigned port
 
-        fileSize = os.path.getsize(filepath)
-        fileName = os.path.basename(filepath)
+        # Create a timeout to close the socket if no connection is made
+        timeoutDeferred = reactor.callLater(60, self.canceldccrequest, listener, user)
 
-        # Start listening for DCC connection
-        listener = reactor.listenTCP(0, DCCSendFactory(filepath))  # Port 0 = auto-assign
-        assignedPort = listener.getHost().port  # Get the assigned port
+        # Update the factory to include the timeout
+        listener.factory = DCCSendFactory(filePath, timeoutDeferred)
 
-        dccmsg = f"\x01DCC SEND {fileName} {ipint} {assignedPort} {fileSize}\x01"
-        self.ctcpMakeQuery(user, [dccmsg])
+        fileSize = os.path.getsize(filePath)
+        fileName = os.path.basename(filePath)
 
-        self.logger.info(f"Started DCC SEND for {fileName} on port {assignedPort}")
+        # Construct and send the DCC SEND CTCP message
+        dcc_msg = f"\x01DCC SEND {fileName} {ipint} {assignedPort} {fileSize}\x01"
+        self.ctcpMakeQuery(user, [dcc_msg])
+
+        print(f"Started DCC SEND for {fileName} to {user} on port {assignedPort}")
+    
+    def canceldccrequest(self, listener, user):
+        """Cancel the DCC request if the receiver does not accept within the timeout."""
+        listener.stopListening()  # Close the port
+        self.msg(user, "DCC SEND request timed out. Please request the file again.")
+        self.logger.info(f"DCC SEND request timed out for user {user}. Closing port.")
 
     def send(self, message):
         """Send a raw message to the server.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
 # Core
-Twisted==23.10.0
+Twisted==24.11.0
 
 # SSL connections
-pyOpenSSL==24.0.0
-service_identity==24.1.0
+pyOpenSSL==25.0.0
+service_identity==24.2.0
 
 # Various URL scraping plugins
-beautifulsoup4==4.12.3
-requests==2.31.0
+beautifulsoup4==4.13.3
+requests==2.32.3


### PR DESCRIPTION
Added DCC functionality to core

## Description
Added the ability to send files with the DCC protocol.

## Test Plan
I created I quick plugin

```
from cardinal.decorators import command, help

# File to be sent
FILE_PATH = "/tmp/test.txt"

class DCCSendPlugin:
    """Plugin to handle !sendfile command and send a file via DCC SEND."""

    @command(["sendfile"])
    def send_file(self, cardinal, user, channel, msg):
        """Sends /tmp/test.txt to the requesting user via DCC SEND."""
        cardinal.senddccfile(user, FILE_PATH)
        cardinal.sendMsg(channel, f"{user}: Sending test.txt via DCC SEND.")

entrypoint = DCCSendPlugin
```

## Contribution Checklist
- [ ] I have read the [contributing guidelines](https://github.com/JohnMaguire/Cardinal/blob/master/CONTRIBUTING.md).
- [ ] I consent to the [MIT project license](https://github.com/JohnMaguire/Cardinal/blob/master/LICENSE).
- [ ] I have added my name to the [`CONTRIBUTORS`](https://github.com/JohnMaguire/Cardinal/blob/master/CONTRIBUTORS) file if desired (optional).
